### PR TITLE
ci: add repo maintainers as dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
     reviewers:
-      - "maintainers"
+      - "ccamel"
+      - "amimart"
+      - "ingvaar"


### PR DESCRIPTION
Because dependabot only supports team and individuals as reviewers, we must specify manually the repo maintainers.
See the [doc](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) for reference.
Note that we can also directly add a team as reviewers, it may be an option to explore.