### PR TITLE
Fix/keep offset state

### DIFF
--- a/src/main/kotlin/com/okp4/connect/cosmos/CosmosSourceTask.kt
+++ b/src/main/kotlin/com/okp4/connect/cosmos/CosmosSourceTask.kt
@@ -58,8 +58,8 @@ class CosmosSourceTask : SourceTask() {
                     .toList()
             }
         }.also {
-            it.takeIf { it.isNotEmpty() }?.let { records ->
-                lastBlockHeightFromOffsetStorage = records[records.size - 1].sourceOffset()[HEIGHT_FIELD] as Long
+            it.lastOrNull()?.run {
+                lastBlockHeightFromOffsetStorage = sourceOffset()[HEIGHT_FIELD] as Long
             }
         }
 


### PR DESCRIPTION
When handling source records, Kafka Connect dissociate the Producer send and the offset save which can lead to successive `poll` calls without fresh offset value.

Instead of systematically fetch the offset value, we keep its populated state across `poll` calls.