### PR TITLE
build: fix project dependency repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ afterEvaluate {
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://maven.pkg.github.com/okp4/kafka-connector-cosmos")
+        url = uri("https://maven.pkg.github.com/okp4/okp4-cosmos-proto")
         credentials {
             username = project.property("maven.credentials.username") as String
             password = project.property("maven.credentials.password") as String
@@ -49,7 +49,7 @@ dependencies {
     api("org.apache.kafka:connect-api:$kafkaVersion")
     compileOnly("org.apache.kafka:connect-runtime:$kafkaVersion")
 
-    val cosmosSdkVersion = "1.0"
+    val cosmosSdkVersion = "1.1"
     implementation("com.okp4.grpc:cosmos-sdk:$cosmosSdkVersion")
 
     val grpcKotlinVersion = "1.2.1"


### PR DESCRIPTION
I didn't follow everything with okp4-cosmos-proto project but it appeared the build was broken. Proto dependencies are in `okp4-cosmos-proto` project, does that make sense?